### PR TITLE
[2주차 세미나] 구현 과제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'org.sopt'
@@ -9,9 +11,30 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion=JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    //Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 test {

--- a/src/main/java/org/sopt/diary/DiaryApplication.java
+++ b/src/main/java/org/sopt/diary/DiaryApplication.java
@@ -1,0 +1,11 @@
+package org.sopt.diary;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DiaryApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DiaryApplication.class, args);
+    }
+}

--- a/src/main/java/org/sopt/diary/Repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/Repository/DiaryRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.diary.Repository;
+
+
+import org.sopt.diary.domain.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findTop10ByOrderByCreatedAtDesc();
+}

--- a/src/main/java/org/sopt/diary/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/diary/advice/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package org.sopt.diary.advice;
+
+import org.sopt.diary.dto.common.ResponseDto;
+import org.sopt.diary.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ResponseDto<String>> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ResponseDto.fail(e.getErrorCode().getCode(),e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+
+        e.getBindingResult().getFieldErrors().forEach((FieldError error) -> {
+            String fieldName = error.getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.failValidate(errors));
+    }
+}

--- a/src/main/java/org/sopt/diary/controller/DiaryController.java
+++ b/src/main/java/org/sopt/diary/controller/DiaryController.java
@@ -1,0 +1,65 @@
+package org.sopt.diary.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.diary.dto.request.DiaryDetailsDto;
+import org.sopt.diary.dto.request.DiaryCreateDto;
+import org.sopt.diary.dto.request.DiaryUpdateDto;
+import org.sopt.diary.dto.response.DiaryListResponse;
+import org.sopt.diary.service.DiaryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    // 일기 작성
+    @PostMapping("/diary")
+    public ResponseEntity<Void> createDiary(
+            @RequestBody @Valid final DiaryCreateDto diaryCreateDto
+            ) {
+        return ResponseEntity.created(URI.create(
+                diaryService.createDiary(diaryCreateDto).getId().toString()
+        )).build();
+    }
+
+    // 일기 상세 조회
+    @GetMapping("/diary/{diaryId}")
+    public ResponseEntity<DiaryDetailsDto> getDiary(
+            @PathVariable final Long diaryId
+    ){
+        return ResponseEntity.ok(diaryService.getDiaryDetails(diaryId));
+    }
+
+    // 일기 목록 조회
+    @GetMapping("/diary")
+    public ResponseEntity<DiaryListResponse> getDiaryList(
+    ){
+        return ResponseEntity.ok(diaryService.getDiaryList());
+    }
+
+    // 일기 수정
+    @PatchMapping("/diary/{diaryId}")
+    public ResponseEntity<Void> updateDiary(
+            @PathVariable final Long diaryId,
+            @RequestBody @Valid final DiaryUpdateDto diaryUpdateDto
+    ){
+        diaryService.updateDiary(diaryId, diaryUpdateDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 일기 제거
+    @DeleteMapping("/diary/{diaryId}")
+    public ResponseEntity<Void> deleteDiary(
+            @PathVariable final Long diaryId
+    ) {
+        diaryService.removeDiary(diaryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/sopt/diary/domain/Diary.java
+++ b/src/main/java/org/sopt/diary/domain/Diary.java
@@ -1,0 +1,35 @@
+package org.sopt.diary.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String title;
+
+    public LocalDateTime createdAt;
+
+    public String content;
+
+    @Builder
+    private Diary(Long id, String title,  String content, LocalDateTime createdAt){
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateDiary(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/org/sopt/diary/dto/common/ResponseDto.java
+++ b/src/main/java/org/sopt/diary/dto/common/ResponseDto.java
@@ -1,0 +1,22 @@
+package org.sopt.diary.dto.common;
+
+public record ResponseDto<T> (
+        String code,
+        T data,
+        String message
+) {
+    public static <T> ResponseDto<T> fail(String code, String message) {
+        return new ResponseDto<>(code, null, message);
+    }
+
+    // Validation 실패 시 응답 형식
+    public static <T> ResponseDto<T> failValidate(final T data) {
+        return new ResponseDto<>("fail", data, null);
+    }
+
+    // 후에 아래처럼 success 에 대해서도 공통된 응답 형식을 반환할 수 있도록 하면 좋은 코드가 될 것 같다.
+    public static <T> ResponseDto<T> success(final T data) {
+        return new ResponseDto<>("success", data, null);
+    }
+
+}

--- a/src/main/java/org/sopt/diary/dto/request/DiaryCreateDto.java
+++ b/src/main/java/org/sopt/diary/dto/request/DiaryCreateDto.java
@@ -1,0 +1,19 @@
+package org.sopt.diary.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record DiaryCreateDto(
+        Long id,
+
+        @NotNull(message = "제목을 입력해주세요.")
+        @Size(max = 10, message = "일기의 제목은 10자 이내여야 합니다.")
+        String title,
+
+        @Size(max = 30, message = "일기의 내용은 30자 이내여야 합니다.")
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/org/sopt/diary/dto/request/DiaryDetailsDto.java
+++ b/src/main/java/org/sopt/diary/dto/request/DiaryDetailsDto.java
@@ -1,0 +1,14 @@
+package org.sopt.diary.dto.request;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record DiaryDetailsDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/org/sopt/diary/dto/request/DiaryUpdateDto.java
+++ b/src/main/java/org/sopt/diary/dto/request/DiaryUpdateDto.java
@@ -1,0 +1,11 @@
+package org.sopt.diary.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record DiaryUpdateDto(
+        @Size(max = 30, message = "일기의 내용은 30자 이내여야 합니다.")
+        String content
+) {
+}

--- a/src/main/java/org/sopt/diary/dto/response/DiaryListResponse.java
+++ b/src/main/java/org/sopt/diary/dto/response/DiaryListResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.diary.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record DiaryListResponse(
+        List<DiaryDto> diaryLists
+) {
+
+    @Builder
+    public record DiaryDto(
+            Long id,
+            String title
+    ){
+    }
+}

--- a/src/main/java/org/sopt/diary/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/diary/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package org.sopt.diary.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode{
+    NOT_FOUND_DIARY(HttpStatus.NOT_FOUND,"error","존재하지 않는 Diary 입니다."),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/diary/exception/NotFoundException.java
+++ b/src/main/java/org/sopt/diary/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package org.sopt.diary.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -1,0 +1,72 @@
+package org.sopt.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.diary.Repository.DiaryRepository;
+import org.sopt.diary.domain.Diary;
+import org.sopt.diary.dto.request.DiaryCreateDto;
+import org.sopt.diary.dto.request.DiaryDetailsDto;
+import org.sopt.diary.dto.request.DiaryUpdateDto;
+import org.sopt.diary.dto.response.DiaryListResponse;
+import org.sopt.diary.exception.ErrorCode;
+import org.sopt.diary.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    @Transactional
+    public Diary createDiary(DiaryCreateDto diaryCreateDto){
+        Diary diary = Diary.builder()
+                .title(diaryCreateDto.title())
+                .content(diaryCreateDto.content())
+                .build();
+        return diaryRepository.save(diary);
+    }
+
+    private Diary findById(final Long diaryId){
+        return diaryRepository.findById(diaryId).orElseThrow(
+                () -> new NotFoundException(ErrorCode.NOT_FOUND_DIARY)
+        );
+    }
+
+    public DiaryDetailsDto getDiaryDetails(final Long diaryId){
+        Diary diary = findById(diaryId);
+
+        return DiaryDetailsDto.builder()
+                .id(diary.getId())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .createdAt(diary.getCreatedAt())
+                .build();
+    }
+
+    public DiaryListResponse getDiaryList(){
+        List<DiaryListResponse.DiaryDto> diaryItems = diaryRepository.findTop10ByOrderByCreatedAtDesc()
+                .stream().map(
+                        diary -> DiaryListResponse.DiaryDto.builder()
+                                .id(diary.getId())
+                                .title(diary.getTitle())
+                                .build()
+                ).toList();
+        return DiaryListResponse.builder().diaryLists(diaryItems).build();
+    }
+
+    @Transactional
+    public void updateDiary(final Long diaryId, DiaryUpdateDto diaryUpdateDto){
+        Diary diary = findById(diaryId);
+        diary.updateDiary(diaryUpdateDto.content());
+    }
+
+    @Transactional
+    public void removeDiary(final Long diaryId){
+        Diary diary = findById(diaryId);
+        diaryRepository.delete(diary);
+    }
+}

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -14,12 +14,9 @@ public class DiaryRepository {
     private final Map<Long, String> deletedStorage = new ConcurrentHashMap<>();
     private final Map<Long, Integer> patchCount = new ConcurrentHashMap<>(); //수정 횟수
     private final Map<Long, LocalDate> patchDate = new ConcurrentHashMap<>(); // 마지막으로 수정한 날짜
-
-public class DiaryRepository {
-    private final Map<Long, String> storage = new ConcurrentHashMap<>();
     private final AtomicLong numbering = new AtomicLong();
 
-    void save(final Diary diary){
+    void save(final Diary diary) {
 
         // 채번 과정(1을 더한 값을 반환)
         final long id = numbering.addAndGet(1);
@@ -39,7 +36,7 @@ public class DiaryRepository {
             final String body = storage.get(index);
 
             // (2-1) 불러온 값을 구성한 자료구조로 이관
-            if(body != null) {
+            if (body != null) {
                 diaryList.add(new Diary(index, body));
             }
         }
@@ -50,7 +47,7 @@ public class DiaryRepository {
 
     void delete(final Long id) {
         String removedDiary = storage.remove(id);
-        if(removedDiary != null){
+        if (removedDiary != null) {
             deletedStorage.put(id, removedDiary);
             patchCount.remove(id);  // 삭제 시 수정 횟수 제거
             patchDate.remove(id);  // 삭제 시 날짜 제거
@@ -61,14 +58,14 @@ public class DiaryRepository {
         LocalDate today = LocalDate.now();
         LocalDate last = patchDate.getOrDefault(id, today);
 
-        if(!today.equals(last)){
+        if (!today.equals(last)) {
             patchCount.put(id, 0);
             patchDate.put(id, today);
         }
 
         int count = patchCount.getOrDefault(id, 0);
 
-        if(count >= 2){
+        if (count >= 2) {
             throw new LimitEditException();
         }
         storage.replace(id, body);
@@ -86,21 +83,11 @@ public class DiaryRepository {
         storage.remove(id);
     }
 
-    void patch(final Long id, final String body) {
-        /*
-        replace() : key 가 존재할 때에만 값을 변경
-        put() : key 가 존재하지 않으면 새로운 key-value 쌍을 추가
-         */
-        storage.replace(id, body);
-
-    }
-
-    boolean existById(final Long id){
+    boolean existById(final Long id) {
         return storage.containsKey(id);
     }
 
-
-    boolean existByDeletedId(final Long id){
+    boolean existByDeletedId(final Long id) {
         return deletedStorage.containsKey(id);
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryValidator.java
+++ b/src/main/java/org/sopt/week1/DiaryValidator.java
@@ -11,7 +11,7 @@ public class DiaryValidator {
         if(body.trim().isEmpty()){
             throw new InvalidInputException();
         }
-        if(body.length() > 30){
+        if(countGraphemeClusters(body) > 30){
             throw new DiaryBodyLengthException();
         }
     }


### PR DESCRIPTION
### ⭐ TODO

**[필수]**
- [x]  일기 작성 (글자수 제한)
- [x]  일기 목록 조회
- [x]  일기 상세조회 (id로 조회)
- [x]  일기 수정 (글자수 제한)
- [x]  일기 삭제

**[선택]** 3주차 세미나 과제와 이어지는 것 같아, 3주차 과제에서 함께 구현 해 보겠습니다.
- [ ] 5분에 하나만 작성 및 응답형식 
- [x] 글자수가 많은 순서 10개 조회 및 정렬
- [ ] 30자 넘길 시 응답코드 고민
- [ ] 일기 수정 일일 2회 제한 기능 추가
- [ ] 중복되는 제목 없게 
- [x] 카테고리 기능 추가 및 조회 


---

### 📚 순서

1. 프로젝트 구성에 관한 초기 세팅 
2. 과제 필수 구현 기능
3. **(⭐) 예외 처리 및 공통 Reponse 형식 처리에 관한 고민 (봉투패턴)**

---

### 계층적 폴더 구조

<img width="382" alt="image" src="https://github.com/user-attachments/assets/dedfb3e4-5d47-4184-969f-7d4a6ff6f604">

- Advice - 예외 처리 관련 코드
- domain - 엔티티 클래스
- dto - 클라이언트와 서버 간의 데이터 교환을 위해 사용하는 객체

### Diary 도메인

```java
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Diary {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    public Long id;
    public String title;
    public LocalDateTime createdAt;
    public String content;

    @Builder
    private Diary(Long id, String title,  String content, LocalDateTime createdAt){
        this.id = id;
        this.title = title;
        this.content = content;
        this.createdAt = LocalDateTime.now();
    }

    public void updateDiary(String content){
        this.content = content;
    }
}
```

- 의존성에 Lombok을 추가해서 `@Getter`, `@Setter`, `@NoArgsConstructor`, `@RequiredArgsConstructor`, `@AllArgsConstructor`, `@Builder` 등의 어노테이션을 사용할 수 있게 했습니다. → 편리성
- `AccessLevel.PROTECTED` : 외부에서 직접 객체 생성하는 것을 제한합니다. → 안정성

### @Transactional(readOnly = true)

```java
@Service
@RequiredArgsConstructor
**@Transactional(readOnly = true)**
public class DiaryService {

    ... ...
}
```

`readOnly = true` 를 클래스 전체에 미리 걸어 둔 다음, 필요한 메서드에서 `@Trasactional` 을 걸어주도록 했습니다. 

👉🏻 **이점**

- 트랜잭션 commit 시 영속성 컨텍스트가 자동으로 flush되지 않으므로 조회용으로 가져온 Entity의 예상치 못한 수정을 방지할 수 있습니다.
- JPA는 해당 트랜잭션 내에서 조회하는 Entity는 단순 조회용임을 인식하고, 변경 감지를 위한 Snapshot을 따로 보관하지 않으므로 메모리가 절약되는 성능상 이점이 존재합니다.

### Record

자동으로 생성자, getter, equals, hashCode, toString 메서드를 생성해줍니다. → 반복적인 코드를 줄일 수 있어 DTO에서 주로 사용합니다.

---

<aside>
1️⃣

**일기 작성** 

</aside>

### Controller

```java
    @PostMapping("/diary")
    public ResponseEntity<Void> createDiary(
            @RequestBody @Valid final DiaryCreateDto diaryCreateDto
            ) {
        return ResponseEntity.created(URI.create(
                diaryService.createDiary(diaryCreateDto).getId().toString()
        )).build();
    }
```

### DiaryCreateDto

```java
public record DiaryCreateDto(
        Long id,

        @NotNull(message = "제목을 입력해주세요.")
        @Size(max = 10, message = "일기의 제목은 10자 이내여야 합니다.")
        String title,

        @Size(max = 30, message = "일기의 내용은 30자 이내여야 합니다.")
        String content,
        LocalDateTime createdAt
) {
}
```

- `@Valid` 를 사용해 컨트롤러 단에서 유효성 검증을 진행했습니다.
- 서비스 단으로 굳이 넘겨서 검증을 하지 않은 이유는, 처음부터 유효하지 않은 데이터를 서비스 단으로 넘겨서 검증할 필요 없이 앞에서 바로 막으면 된다고 생각해 서비스 단에서는 비즈니스 로직만 처리하도록 하기 위함입니다.
- 유효성 검사 실패 시, 자동으로 400 Bad Request를 반환합니다. (추후 뒤에서 GlobalExceptionHandler 에서 커스텀 에러 핸들링 해줍니다)

<aside>
2️⃣

**일기 목록 조회**

</aside>

### Controller

```java
  @GetMapping("/diary")
    public ResponseEntity<DiaryListResponse> getDiaryList(
    ){
        return ResponseEntity.ok(diaryService.getDiaryList());
    }
```

### DiaryListResponse

```java
@Builder
public record DiaryListResponse(
        List<DiaryDto> diaryLists
) {

    @Builder
    public record DiaryDto(
            Long id,
            String title
    ){
    }
}
```

### Service

```java
  public DiaryListResponse getDiaryList(){
        List<DiaryListResponse.DiaryDto> diaryItems = diaryRepository.findTop10ByOrderByCreatedAtDesc()
                .stream().map(
                        diary -> DiaryListResponse.DiaryDto.builder()
                                .id(diary.getId())
                                .title(diary.getTitle())
                                .build()
                ).toList();
        return DiaryListResponse.builder().diaryLists(diaryItems).build();
    }
```

- DiaryRepository에 `List<Diary> findTop10ByOrderByCreatedAtDesc();` 를 정의했습니다.
    - JPA Repository 에서 제공하는 메소드
    - createdAt 필드 기준으로 내림차순 정렬 한 후, 가장 위의 10개를 반환

<aside>
3️⃣

일기 상세 조회

</aside>

### Controller

```java
    @GetMapping("/diary/{diaryId}")
    public ResponseEntity<DiaryDetailsDto> getDiary(
            @PathVariable final Long diaryId
    ){
        return ResponseEntity.ok(diaryService.getDiaryDetails(diaryId));
    }
```

### Service

```java
    private Diary findById(final Long diaryId){
        return diaryRepository.findById(diaryId).orElseThrow(
                () -> new NotFoundException(ErrorCode.NOT_FOUND_DIARY)
        );
    }

    public DiaryDetailsDto getDiaryDetails(final Long diaryId){
        Diary diary = findById(diaryId);

        return DiaryDetailsDto.builder()
                .id(diary.getId())
                .title(diary.getTitle())
                .content(diary.getContent())
                .createdAt(diary.getCreatedAt())
                .build();
    }
```

`findById()` 를 정의해서 DiaryRepository 에서 일기의 Id 로 저장된 일기를 찾아올 수 있도록 했습니다. 저장 안된 일기를 찾으려고 할 경우에는 예외를 발생시킵니다.

<aside>
4️⃣

**일기 수정**

</aside>

### Controller

```java
    public ResponseEntity<Void> updateDiary(
            @PathVariable final Long diaryId,
            @RequestBody @Valid final DiaryUpdateDto diaryUpdateDto
    ){
        diaryService.updateDiary(diaryId, diaryUpdateDto);
        return ResponseEntity.noContent().build();
    }
```

### Service

```java
    @Transactional
    public void updateDiary(final Long diaryId, DiaryUpdateDto diaryUpdateDto){
        Diary diary = findById(diaryId);
        diary.updateDiary(diaryUpdateDto.content());
    }
```

<aside>
5️⃣

**일기 제거**

</aside>

### Controller

```java
   @DeleteMapping("/diary/{diaryId}")
    public ResponseEntity<Void> deleteDiary(
            @PathVariable final Long diaryId
    ) {
        diaryService.removeDiary(diaryId);
        return ResponseEntity.noContent().build();
    }
```

### Service

```java
    @Transactional
    public void removeDiary(final Long diaryId){
        Diary diary = findById(diaryId);
        diaryRepository.delete(diary);
    }
```

---

## ✅ 예외 처리 및 공통 응답 형식 (봉투패턴)

### ▶️ Exception

```java
@Getter
@RequiredArgsConstructor
public class NotFoundException extends RuntimeException {
    private final ErrorCode errorCode;
}
```

`GlobalExceptionHandler` 클래스에서 해당 예외를 처리할 수 있습니다.

```java
@Getter
@AllArgsConstructor
public enum ErrorCode{
    NOT_FOUND_DIARY(HttpStatus.NOT_FOUND,"error","존재하지 않는 Diary 입니다."),
    ;

    @JsonIgnore
    private final HttpStatus httpStatus;
    private final String code;
    private final String message;
}
```

- **enum 클래스에** 에러 코드를 정의했습니다. 후에 다른 여러가지 에러코드들을 추가할 수 있습니다.
    - 추후 상황에 따라 ErrorCode enum 클래스 또한 `NotFoundErrorCode`, `IllegalArgumentErrorCode`, `UnAuthorizedErrorCode` 등의 여러 enum 클래스로 유형별로 분리하여 사용할 수도 있습니다. (현재는 너무 작은 프로젝트이기 때문에 ErrorCode 로 정의했습니다)
- `@JsonIgnore` : HttpStatus JSON 응답에 표현되지 않게 해서 불필요한 정보를 클라이언트에게 굳이 제공하지 않도록 했습니다.

### ▶️  GlobalExceptionHandler

```java
@RestControllerAdvice
public class GlobalExceptionHandler {

    @ExceptionHandler(NotFoundException.class)
    public ResponseEntity<ResponseDto<String>> handleNotFoundException(NotFoundException e) {
        return ResponseEntity
                .status(e.getErrorCode().getHttpStatus())
                .body(ResponseDto.fail(e.getErrorCode().getCode(),e.getErrorCode().getMessage()));
                
          ... 생략
    }
```

- `@RestControllerAdvice` : 전역 예외 처리, JSON 형식의 응답 반환에 적합

### ▶️ 공통된 응답, ResponseDto (Common)

- 이 클래스는 모든 응답을 동일한 구조로 감싸는 역할을 합니다. → “**봉투패턴”**
- code 는 응답의 성공("success")과 실패("fail") 상태를 나타내고, data 는 실제 응답 데이터를, message는 오류 메시지를 담아 클라이언트에게 **일관된 형태의 응답 구조**를 제공합니다.
    - GlobalExceptionHandler 클래스에서 예외를 처리할 때, ResponseDto를 안의 fail 함수를 호출하면 클라이언트에게 일관된 응답 형식을 반환할 수 있게 합니다.

```java
public record ResponseDto<T> (
        String code,
        T data,
        String message
) {
    public static <T> ResponseDto<T> fail(String code, String message) {
        return new ResponseDto<>(code, null, message);
    }
}
```

- public record ResponseDto<T> ( ) { }
    - 제네릭 적용해서 ResponseDto 에 다양한 유형의 데이터들이 담길 수 있도록 했습니다.

→ 존재하지 않는 일기의 Id 로 검색할 경우 아래와 같은 응답이 반환됩니다.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/34e4f11e-2101-4f19-adc2-7e406c03f1d8">

### ❗여기서 잠깐 ❗

앞서 Controller에서 `@Valid` 어노테이션을 사용해서 입력한 제목과 내용의 글자수를 검증하는 과정을 진행했었습니다. 

1. `@Valid` 를 사용해서 예외가 발생했을 시에는 MethodArgumentNotValidException 가 발생하게 됩니다.
2. But, 이를 커스텀 해주지 않으면 스프링이 기본적으로 제공하는 예외 응답이 반환되어서 클라이언트에게 일관된 형식으로 응답을 제공할 수 없었습니다. 아래처럼요!

<img width="542" alt="image" src="https://github.com/user-attachments/assets/345da7e7-7638-499d-b1aa-b45770a9ff67">


3. 콘솔에만 messeage로 정의했던 문구가 출력되는 것을 확인할 수 있었습니다.

![image](https://github.com/user-attachments/assets/4ad202fe-3ca8-4f21-bed6-905d229e4aa8)
그래서, `GlobalExceptionHandler` 클래스에서 `MethodArgumentNotValidException.class` 에 대한 예외 처리를 커스텀해서 ResponsEntity를 custom한 객체로 만들어서 보내주었습니다.

### GlobalExceptionHandler

```java
    @ExceptionHandler(MethodArgumentNotValidException.class)
    public ResponseEntity<ResponseDto<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException e) {
        Map<String, String> errors = new HashMap<>();

        e.getBindingResult().getFieldErrors().forEach((FieldError error) -> {
            String fieldName = error.getField();
            String errorMessage = error.getDefaultMessage();
            errors.put(fieldName, errorMessage);
        });

        return ResponseEntity
                .status(HttpStatus.BAD_REQUEST)
                .body(ResponseDto.failValidate(errors));
    }
```

### ResponseDto

```java
    // Validation 실패 시 응답 형식
    public static <T> ResponseDto<T> failValidate(final T data) {
        return new ResponseDto<>("fail", data, null);
    }
```

→ 일기의 제목, 내용 모두 지정된 글자수를 초과할 경우

![image](https://github.com/user-attachments/assets/71265abc-88c4-4d07-b980-88d0ce07d5da)

→ 일기의 제목만 지정된 글자수를 초과할 경우

![image](https://github.com/user-attachments/assets/8cfcdd62-3271-485b-beb9-a4df09d87efa)

→ 일기의 제목을 쓰지 않았을(null) 경우

![image](https://github.com/user-attachments/assets/65d6337a-1761-4731-8fd6-f4ee8bd9c031)

➕ TIP

현 과제에서는 사용되지 않았으나, 후에 success 요청에도 활용할 수 있겠습니다! 이를 통해 실패, 성공 응답 모두 일관된 형식으로 클라이언트에게 반환할 수 있게 됩니다.

```java
    // 후에 아래처럼 success 에 대해서도 공통된 응답 형식을 반환할 수 있도록 하면 좋은 코드가 될 것 같다.
    public static <T> ResponseDto<T> success(final T data) {
        return new ResponseDto<>("success", data, null);
    }
```

---

**참고 블로그**

[[SpringBoot] ResponseBodyAdvice를 이용한 공통 응답 처리와, 관련 트러블 슈팅](https://velog.io/@kylekim2123/SpringBoot-ResponseBodyAdvice%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EA%B3%B5%ED%86%B5-%EC%9D%91%EB%8B%B5-%EC%B2%98%EB%A6%AC%EC%99%80-%EA%B4%80%EB%A0%A8-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85)
[[SpringBoot]Validation 에러 처리하기](https://deviscreen.tistory.com/124)